### PR TITLE
Clipboard linux

### DIFF
--- a/lib/meme.rb
+++ b/lib/meme.rb
@@ -137,10 +137,18 @@ class Meme
   end
 
   ##
-  # Puts +link+ in your clipboard, if you're on OS X, that is.
+  # Tries to find clipboard copy executable and if found puts +link+ in your
+  # clipboard.
 
   def paste link
-    IO.popen 'pbcopy', 'w' do |io| io.write link end
+    clipboard = %w{
+      /usr/bin/pbcopy
+      /usr/bin/xclip
+    }.find { |path| File.exist? path }
+
+    if clipboard
+      IO.popen clipboard, 'w' do |io| io.write link end
+    end
   end
 
 end


### PR DESCRIPTION
This patch prevents pbcopy not found on Linux. It tries to use xclip but does not error if no clipboard copy executables can be found.
