### PR TITLE
Don't add nil default line

### DIFF
--- a/lib/meme.rb
+++ b/lib/meme.rb
@@ -162,8 +162,10 @@ class Meme
     res = nil
     location = nil
 
-    # Put the default line in front unless theres more than 1 text input.
-    args.unshift(@default_line) unless args.size > 1
+    # Prepend the default line if this meme has one and we only had 1 text input
+    if @default_line && args.size <= 1
+      args.unshift(@default_line)
+    end
 
     raise Error, "two lines are required for #{@generator_name}" unless args.size > 1
 


### PR DESCRIPTION
I added a nil check for @default_line so that the user gets the  "two lines are required for #{@generator_name}" error if the generator doesn't have a default line and the user only provides one line of input text.
## This prevents the following sort of confusing error from happening.

```
meme sparta "hi"
ERROR: bad argument(expected URI object or URI string) (ArgumentError)
```

---
