### PR TITLE
Skip clipboard and pull of the image with --text flag

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,6 +18,10 @@ Generate a Y U NO meme:
 
   $ meme Y_U_NO 'write tests?'
 
+Generate a Y U NO meme url only, no clipboard or pulling of the image data:
+
+  $ meme --text Y_U_NO 'write tests?'
+
 See a list of available generators
 
   $ meme --list

--- a/lib/meme.rb
+++ b/lib/meme.rb
@@ -125,14 +125,23 @@ class Meme
       exit
     end
 
+    text_only = if generator == '--text'
+      generator = ARGV.shift
+      true
+    else
+      false
+    end
+
+    # puts "text_only:#{text_only} generator:#{generator}"
+
     abort "#{$0} [GENERATOR|--list] LINE [ADDITONAL_LINES]" if ARGV.empty?
 
     meme = new generator
     link = meme.generate *ARGV
 
-    meme.paste link
+    meme.paste(link) unless text_only
 
-    if $stdout.tty?
+    if $stdout.tty? || text_only
       puts link
     else
       puts meme.fetch link


### PR DESCRIPTION
Added a --text flag to the call that will skip the clipboard operations and pulling of the image data.

Required this for integrating with a campfire bot that runs on a OS X box.

Cheers,
Mike D.
